### PR TITLE
Fix auth flow for admin access after GitHub login

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -37,32 +37,47 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const initializeSession = async () => {
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+
+      if (error) {
+        console.error("Error getting initial session:", error.message);
+      }
+
+      setUser(session?.user ?? null);
+      setIsLoading(false);
+    };
+
+    initializeSession();
+
     const { data: listener } = supabase.auth.onAuthStateChange(
       (_event, session) => {
-        console.log("session onAuthStateChange: ", session);
-        if (session) {
-          console.log("Setting user: ", session.user);
-          setUser(session.user);
-        }
+        setUser(session?.user ?? null);
         setIsLoading(false);
       },
     );
+
     return () => {
-      listener?.subscription.unsubscribe();
+      listener.subscription.unsubscribe();
     };
   }, []);
 
   const signIn = async () => {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: "github",
-      options: { skipBrowserRedirect: false },
+      options: {
+        skipBrowserRedirect: false,
+        redirectTo: `${window.location.origin}/admin`,
+      },
     });
-    console.log("data: ", data);
-    console.log("error: ", error);
 
     if (error) {
       console.error("Error signing in with GitHub:", error.message);
     }
+
     return { data: data as OAuthResponse | null, error };
   };
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Heading } from "../components/Heading";
 import { Button } from "../components/Button";
 import { FaGithub } from "react-icons/fa6";
@@ -6,32 +7,41 @@ import { useAuth } from "../components/AuthProvider";
 import { useNavigate } from "react-router-dom";
 
 export function LoginPage() {
-  const {user, signIn } = useAuth();
+  const { user, signIn } = useAuth();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user) {
+      navigate("/admin", { replace: true });
+    }
+  }, [navigate, user]);
+
   const handleLogin = async () => {
     const { error } = await signIn();
 
     if (error) {
       alert("An error occurred during sign in: " + error.message);
-      return;
     }
-    
-    if (user) {
-      navigate("/admin");
-    }
-  }
+  };
 
   return (
     <section className="space-y-6">
       <Heading text="Login" />
       <div className="flex justifty-between">
         <div className="space-y-6">
-          <p>Are you sure you're Jolene Kearse, the most awesome Software Engineer?</p>
+          <p>
+            Are you sure you're Jolene Kearse, the most awesome Software
+            Engineer?
+          </p>
           <p>You better login to verify your identity!</p>
         </div>
         <img src={Jolene} alt="me" className="size-28" />
       </div>
-      <Button text="Login with GitHub" icon={<FaGithub />} onClick={handleLogin} />
+      <Button
+        text="Login with GitHub"
+        icon={<FaGithub />}
+        onClick={handleLogin}
+      />
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- The app's auth state could be empty after returning from OAuth, which prevented users from reaching the protected admin page and caused confusing login behavior.
- The previous login flow assumed `user` would be populated immediately after `signIn()`, which is not reliable for redirect-based OAuth.

### Description
- Initialize auth state on app start by calling `supabase.auth.getSession()` and set `user`/`isLoading` accordingly in `src/components/AuthProvider.tsx`.
- Simplify the `onAuthStateChange` handler to set `user` to `session?.user ?? null` so both sign-in and sign-out are handled consistently in `src/components/AuthProvider.tsx`.
- Add an OAuth `redirectTo: \\`${window.location.origin}/admin\\`` option to `supabase.auth.signInWithOAuth()` so GitHub login redirects to the protected admin route, in `src/components/AuthProvider.tsx`.
- Update `src/pages/LoginPage.tsx` to use `useEffect` to redirect authenticated users to `/admin` when `user` state becomes available and remove the timing-sensitive immediate post-sign-in check.

### Testing
- Ran `npm run build` and the production build completed successfully with no build errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef27c3bd083278bb26b3eb246ccf0)