### PR TITLE
Initialize Supabase session, add GitHub redirect, and enforce auth for project creation

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -37,32 +37,47 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const initializeSession = async () => {
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+
+      if (error) {
+        console.error("Error getting initial session:", error.message);
+      }
+
+      setUser(session?.user ?? null);
+      setIsLoading(false);
+    };
+
+    initializeSession();
+
     const { data: listener } = supabase.auth.onAuthStateChange(
       (_event, session) => {
-        console.log("session onAuthStateChange: ", session);
-        if (session) {
-          console.log("Setting user: ", session.user);
-          setUser(session.user);
-        }
+        setUser(session?.user ?? null);
         setIsLoading(false);
       },
     );
+
     return () => {
-      listener?.subscription.unsubscribe();
+      listener.subscription.unsubscribe();
     };
   }, []);
 
   const signIn = async () => {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: "github",
-      options: { skipBrowserRedirect: false },
+      options: {
+        skipBrowserRedirect: false,
+        redirectTo: `${window.location.origin}/admin`,
+      },
     });
-    console.log("data: ", data);
-    console.log("error: ", error);
 
     if (error) {
       console.error("Error signing in with GitHub:", error.message);
     }
+
     return { data: data as OAuthResponse | null, error };
   };
 

--- a/src/components/ProjectForm.tsx
+++ b/src/components/ProjectForm.tsx
@@ -6,6 +6,7 @@ import {
   handleFileUpload,
   // updateProject,
 } from "../services/projectActions";
+import { useAuth } from "./AuthProvider";
 
 type ProjectFormProps = {
   selectedProject?: Project;
@@ -13,6 +14,7 @@ type ProjectFormProps = {
 };
 
 export function ProjectForm({ selectedProject, mode }: ProjectFormProps) {
+  const { user } = useAuth();
   const titleRef = useRef<HTMLInputElement>(null);
   const imgRef = useRef<HTMLInputElement>(null);
   const imgAltRef = useRef<HTMLInputElement>(null);
@@ -25,6 +27,11 @@ export function ProjectForm({ selectedProject, mode }: ProjectFormProps) {
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
+
+    if (!user?.id) {
+      alert("You must be logged in to add a project.");
+      return;
+    }
 
     // handle image and video uploads
     const imgFile = imgRef.current?.files?.[0];
@@ -49,7 +56,7 @@ export function ProjectForm({ selectedProject, mode }: ProjectFormProps) {
       techUsed: [] as string[],
       video: videoPath || "",
       challenges: (challengesRef.current?.value as string) || "",
-      user_id: "fabd38a7-9f69-4e2b-afb3-14df4d2d73b1",
+      user_id: selectedProject?.user_id || user.id,
     };
 
     // get the selected tech used

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Heading } from "../components/Heading";
 import { Button } from "../components/Button";
 import { FaGithub } from "react-icons/fa6";
@@ -6,32 +7,41 @@ import { useAuth } from "../components/AuthProvider";
 import { useNavigate } from "react-router-dom";
 
 export function LoginPage() {
-  const {user, signIn } = useAuth();
+  const { user, signIn } = useAuth();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user) {
+      navigate("/admin", { replace: true });
+    }
+  }, [navigate, user]);
+
   const handleLogin = async () => {
     const { error } = await signIn();
 
     if (error) {
       alert("An error occurred during sign in: " + error.message);
-      return;
     }
-    
-    if (user) {
-      navigate("/admin");
-    }
-  }
+  };
 
   return (
     <section className="space-y-6">
       <Heading text="Login" />
       <div className="flex justifty-between">
         <div className="space-y-6">
-          <p>Are you sure you're Jolene Kearse, the most awesome Software Engineer?</p>
+          <p>
+            Are you sure you're Jolene Kearse, the most awesome Software
+            Engineer?
+          </p>
           <p>You better login to verify your identity!</p>
         </div>
         <img src={Jolene} alt="me" className="size-28" />
       </div>
-      <Button text="Login with GitHub" icon={<FaGithub />} onClick={handleLogin} />
+      <Button
+        text="Login with GitHub"
+        icon={<FaGithub />}
+        onClick={handleLogin}
+      />
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Ensure the app reads an existing Supabase session on startup and correctly reflects auth state changes so the UI doesn't briefly show unauthenticated views.
- Redirect users back to the admin area after completing GitHub OAuth to streamline the login flow.
- Prevent unauthenticated users from creating projects and automatically redirect already-authenticated users away from the login page.

### Description
- Add `initializeSession` in `AuthProvider` that calls `supabase.auth.getSession()` on mount and sets `user`/`isLoading` accordingly, and simplify the `onAuthStateChange` handler to use `session?.user`.
- Add `redirectTo: `${window.location.origin}/admin`` to the GitHub OAuth call in `signIn`, and retain the loading UI while `isLoading` is true.
- Import and use `useAuth` in `ProjectForm`, block submission when no authenticated `user` is present, and replace the hardcoded `user_id` with `selectedProject?.user_id || user.id` when creating projects.
- Add an effect in `LoginPage` to automatically navigate to `/admin` when `user` is present and tidy up small formatting/console-log removals.

### Testing
- Ran TypeScript typecheck with `tsc --noEmit` which completed successfully.
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef27c3bd083278bb26b3eb246ccf0)