### PR TITLE
Initialize Supabase session, enforce auth for project creation, add login redirect and fallback projects

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -37,32 +37,47 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const initializeSession = async () => {
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+
+      if (error) {
+        console.error("Error getting initial session:", error.message);
+      }
+
+      setUser(session?.user ?? null);
+      setIsLoading(false);
+    };
+
+    initializeSession();
+
     const { data: listener } = supabase.auth.onAuthStateChange(
       (_event, session) => {
-        console.log("session onAuthStateChange: ", session);
-        if (session) {
-          console.log("Setting user: ", session.user);
-          setUser(session.user);
-        }
+        setUser(session?.user ?? null);
         setIsLoading(false);
       },
     );
+
     return () => {
-      listener?.subscription.unsubscribe();
+      listener.subscription.unsubscribe();
     };
   }, []);
 
   const signIn = async () => {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: "github",
-      options: { skipBrowserRedirect: false },
+      options: {
+        skipBrowserRedirect: false,
+        redirectTo: `${window.location.origin}/admin`,
+      },
     });
-    console.log("data: ", data);
-    console.log("error: ", error);
 
     if (error) {
       console.error("Error signing in with GitHub:", error.message);
     }
+
     return { data: data as OAuthResponse | null, error };
   };
 

--- a/src/components/ProjectForm.tsx
+++ b/src/components/ProjectForm.tsx
@@ -6,6 +6,7 @@ import {
   handleFileUpload,
   // updateProject,
 } from "../services/projectActions";
+import { useAuth } from "./AuthProvider";
 
 type ProjectFormProps = {
   selectedProject?: Project;
@@ -13,6 +14,7 @@ type ProjectFormProps = {
 };
 
 export function ProjectForm({ selectedProject, mode }: ProjectFormProps) {
+  const { user } = useAuth();
   const titleRef = useRef<HTMLInputElement>(null);
   const imgRef = useRef<HTMLInputElement>(null);
   const imgAltRef = useRef<HTMLInputElement>(null);
@@ -25,6 +27,11 @@ export function ProjectForm({ selectedProject, mode }: ProjectFormProps) {
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
+
+    if (!user?.id) {
+      alert("You must be logged in to add a project.");
+      return;
+    }
 
     // handle image and video uploads
     const imgFile = imgRef.current?.files?.[0];
@@ -49,7 +56,7 @@ export function ProjectForm({ selectedProject, mode }: ProjectFormProps) {
       techUsed: [] as string[],
       video: videoPath || "",
       challenges: (challengesRef.current?.value as string) || "",
-      user_id: "fabd38a7-9f69-4e2b-afb3-14df4d2d73b1",
+      user_id: selectedProject?.user_id || user.id,
     };
 
     // get the selected tech used

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Heading } from "../components/Heading";
 import { Button } from "../components/Button";
 import { FaGithub } from "react-icons/fa6";
@@ -6,32 +7,41 @@ import { useAuth } from "../components/AuthProvider";
 import { useNavigate } from "react-router-dom";
 
 export function LoginPage() {
-  const {user, signIn } = useAuth();
+  const { user, signIn } = useAuth();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user) {
+      navigate("/admin", { replace: true });
+    }
+  }, [navigate, user]);
+
   const handleLogin = async () => {
     const { error } = await signIn();
 
     if (error) {
       alert("An error occurred during sign in: " + error.message);
-      return;
     }
-    
-    if (user) {
-      navigate("/admin");
-    }
-  }
+  };
 
   return (
     <section className="space-y-6">
       <Heading text="Login" />
       <div className="flex justifty-between">
         <div className="space-y-6">
-          <p>Are you sure you're Jolene Kearse, the most awesome Software Engineer?</p>
+          <p>
+            Are you sure you're Jolene Kearse, the most awesome Software
+            Engineer?
+          </p>
           <p>You better login to verify your identity!</p>
         </div>
         <img src={Jolene} alt="me" className="size-28" />
       </div>
-      <Button text="Login with GitHub" icon={<FaGithub />} onClick={handleLogin} />
+      <Button
+        text="Login with GitHub"
+        icon={<FaGithub />}
+        onClick={handleLogin}
+      />
     </section>
   );
 }

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -5,16 +5,28 @@ import { ProjectCard } from "../components/ProjectCard";
 
 import { Project } from "../types/types";
 import { getProjects } from "../services/projectActions";
+import { projects as fallbackProjects } from "../data/projects";
 
 export function ProjectsPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
+  const [usingFallback, setUsingFallback] = useState(false);
 
   useEffect(() => {
     const fetchProjects = async () => {
-      const data = await getProjects();
-      setProjects(data);
-      setLoading(false);
+      try {
+        const data = await getProjects();
+
+        if (!data.length) {
+          setProjects(fallbackProjects);
+          setUsingFallback(true);
+          return;
+        }
+
+        setProjects(data);
+      } finally {
+        setLoading(false);
+      }
     };
 
     fetchProjects();
@@ -34,6 +46,12 @@ export function ProjectsPage() {
   return (
     <section className="space-y-6">
       <Heading text="Jolene's Projects" />
+      {usingFallback && (
+        <p className="rounded-xl bg-purple-900 px-4 py-3 text-purple-300">
+          Couldn&apos;t load projects from Supabase right now, so these are local
+          fallback projects.
+        </p>
+      )}
       <ul className="flex flex-col md:grid md:grid-cols-2 md:gap-6 lg:grid-cols-2">
         {projects.map((project: Project) => (
           <ProjectCard key={project.id} project={project} />


### PR DESCRIPTION
### Motivation
- Ensure the app recognizes the current Supabase session on load so user state is accurate before rendering.
- Prevent anonymous users from creating projects and replace a hardcoded `user_id` with the signed-in user's id.
- Redirect already-authenticated users away from the login page and provide a specific OAuth redirect back to the admin panel.
- Provide local fallback projects when Supabase returns no projects to improve resiliency and user experience.

### Description
- `AuthProvider.tsx`: initialize session on mount via `supabase.auth.getSession()`, simplify `onAuthStateChange` handling, add `redirectTo` option for `signInWithOAuth`, and show a loading state until session is resolved. 
- `ProjectForm.tsx`: require an authenticated user before submitting, remove hardcoded `user_id` and use `user.id` (or existing selected project's `user_id`), and import `useAuth` to access current user. 
- `LoginPage.tsx`: add `useEffect` to navigate to `/admin` when already logged in, tidy JSX formatting, and handle the sign-in flow consistently. 
- `ProjectsPage.tsx`: try fetching projects from Supabase and fall back to local `projects` data when the remote list is empty while exposing a banner when fallback data is used. 

### Testing
- Ran `npm run build` locally to verify the app compiles successfully and the dev build completes without errors. 
- Ran the existing test suite with `npm test` and observed all tests passing locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef27c3bd083278bb26b3eb246ccf0)