### PR TITLE
Initialize Supabase session, add auth redirects, protect ProjectForm, provide projects fallback, and add .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+auto-install-peers=true

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -37,32 +37,47 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
+    const initializeSession = async () => {
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+
+      if (error) {
+        console.error("Error getting initial session:", error.message);
+      }
+
+      setUser(session?.user ?? null);
+      setIsLoading(false);
+    };
+
+    initializeSession();
+
     const { data: listener } = supabase.auth.onAuthStateChange(
       (_event, session) => {
-        console.log("session onAuthStateChange: ", session);
-        if (session) {
-          console.log("Setting user: ", session.user);
-          setUser(session.user);
-        }
+        setUser(session?.user ?? null);
         setIsLoading(false);
       },
     );
+
     return () => {
-      listener?.subscription.unsubscribe();
+      listener.subscription.unsubscribe();
     };
   }, []);
 
   const signIn = async () => {
     const { data, error } = await supabase.auth.signInWithOAuth({
       provider: "github",
-      options: { skipBrowserRedirect: false },
+      options: {
+        skipBrowserRedirect: false,
+        redirectTo: `${window.location.origin}/admin`,
+      },
     });
-    console.log("data: ", data);
-    console.log("error: ", error);
 
     if (error) {
       console.error("Error signing in with GitHub:", error.message);
     }
+
     return { data: data as OAuthResponse | null, error };
   };
 

--- a/src/components/ProjectForm.tsx
+++ b/src/components/ProjectForm.tsx
@@ -6,6 +6,7 @@ import {
   handleFileUpload,
   // updateProject,
 } from "../services/projectActions";
+import { useAuth } from "./AuthProvider";
 
 type ProjectFormProps = {
   selectedProject?: Project;
@@ -13,6 +14,7 @@ type ProjectFormProps = {
 };
 
 export function ProjectForm({ selectedProject, mode }: ProjectFormProps) {
+  const { user } = useAuth();
   const titleRef = useRef<HTMLInputElement>(null);
   const imgRef = useRef<HTMLInputElement>(null);
   const imgAltRef = useRef<HTMLInputElement>(null);
@@ -25,6 +27,11 @@ export function ProjectForm({ selectedProject, mode }: ProjectFormProps) {
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
+
+    if (!user?.id) {
+      alert("You must be logged in to add a project.");
+      return;
+    }
 
     // handle image and video uploads
     const imgFile = imgRef.current?.files?.[0];
@@ -49,7 +56,7 @@ export function ProjectForm({ selectedProject, mode }: ProjectFormProps) {
       techUsed: [] as string[],
       video: videoPath || "",
       challenges: (challengesRef.current?.value as string) || "",
-      user_id: "fabd38a7-9f69-4e2b-afb3-14df4d2d73b1",
+      user_id: selectedProject?.user_id || user.id,
     };
 
     // get the selected tech used

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Heading } from "../components/Heading";
 import { Button } from "../components/Button";
 import { FaGithub } from "react-icons/fa6";
@@ -6,32 +7,41 @@ import { useAuth } from "../components/AuthProvider";
 import { useNavigate } from "react-router-dom";
 
 export function LoginPage() {
-  const {user, signIn } = useAuth();
+  const { user, signIn } = useAuth();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (user) {
+      navigate("/admin", { replace: true });
+    }
+  }, [navigate, user]);
+
   const handleLogin = async () => {
     const { error } = await signIn();
 
     if (error) {
       alert("An error occurred during sign in: " + error.message);
-      return;
     }
-    
-    if (user) {
-      navigate("/admin");
-    }
-  }
+  };
 
   return (
     <section className="space-y-6">
       <Heading text="Login" />
       <div className="flex justifty-between">
         <div className="space-y-6">
-          <p>Are you sure you're Jolene Kearse, the most awesome Software Engineer?</p>
+          <p>
+            Are you sure you're Jolene Kearse, the most awesome Software
+            Engineer?
+          </p>
           <p>You better login to verify your identity!</p>
         </div>
         <img src={Jolene} alt="me" className="size-28" />
       </div>
-      <Button text="Login with GitHub" icon={<FaGithub />} onClick={handleLogin} />
+      <Button
+        text="Login with GitHub"
+        icon={<FaGithub />}
+        onClick={handleLogin}
+      />
     </section>
   );
 }

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -5,16 +5,28 @@ import { ProjectCard } from "../components/ProjectCard";
 
 import { Project } from "../types/types";
 import { getProjects } from "../services/projectActions";
+import { projects as fallbackProjects } from "../data/projects";
 
 export function ProjectsPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
+  const [usingFallback, setUsingFallback] = useState(false);
 
   useEffect(() => {
     const fetchProjects = async () => {
-      const data = await getProjects();
-      setProjects(data);
-      setLoading(false);
+      try {
+        const data = await getProjects();
+
+        if (!data.length) {
+          setProjects(fallbackProjects);
+          setUsingFallback(true);
+          return;
+        }
+
+        setProjects(data);
+      } finally {
+        setLoading(false);
+      }
     };
 
     fetchProjects();
@@ -34,6 +46,12 @@ export function ProjectsPage() {
   return (
     <section className="space-y-6">
       <Heading text="Jolene's Projects" />
+      {usingFallback && (
+        <p className="rounded-xl bg-purple-900 px-4 py-3 text-purple-300">
+          Couldn&apos;t load projects from Supabase right now, so these are local
+          fallback projects.
+        </p>
+      )}
       <ul className="flex flex-col md:grid md:grid-cols-2 md:gap-6 lg:grid-cols-2">
         {projects.map((project: Project) => (
           <ProjectCard key={project.id} project={project} />


### PR DESCRIPTION
### Motivation
- Ensure the app initializes the Supabase session on load so the current user is known immediately.
- Redirect authenticated users to `/admin` after login and ensure sign-in redirects back to the admin page.
- Prevent unauthenticated users from creating projects and associate new projects with the logged-in user's id.
- Provide a local fallback for projects when Supabase returns no data and add `.npmrc` to auto-install peer deps.

### Description
- Added `initializeSession` in `AuthProvider` to call `supabase.auth.getSession()` on mount and set initial `user` and `isLoading` state, simplified `onAuthStateChange` handling, and removed debug logs.
- Updated `signIn` in `AuthProvider` to include `redirectTo: `${window.location.origin}/admin`` in OAuth options.
- Imported and used `useAuth` in `ProjectForm`, added a guard that alerts and aborts submission when no `user` is present, and set `user_id` to `selectedProject?.user_id || user.id` when creating projects.
- Added a `useEffect` in `LoginPage` to navigate to `/admin` when `user` becomes available and cleaned up minor JSX formatting.
- Implemented a fallback mechanism in `ProjectsPage` that imports `projects` from `../data/projects`, uses `usingFallback` state when Supabase returns no projects, and displays a banner describing the fallback.
- Added `.npmrc` with `auto-install-peers=true` to simplify dependency installations.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bef27c3bd083278bb26b3eb246ccf0)