### PR TITLE
Sort project cards by latest GitHub activity

### DIFF
--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -4,7 +4,7 @@ import { Heading } from "../components/Heading";
 import { ProjectCard } from "../components/ProjectCard";
 
 import { Project } from "../types/types";
-import { getProjects } from "../services/projectActions";
+import { getProjects, sortProjectsByGithubLastUpdated } from "../services/projectActions";
 import { projects as fallbackProjects } from "../data/projects";
 
 export function ProjectsPage() {
@@ -18,12 +18,16 @@ export function ProjectsPage() {
         const data = await getProjects();
 
         if (!data.length) {
-          setProjects([...fallbackProjects].reverse());
+          const sortedFallbackProjects = await sortProjectsByGithubLastUpdated(
+            fallbackProjects,
+          );
+          setProjects(sortedFallbackProjects);
           setUsingFallback(true);
           return;
         }
 
-        setProjects([...data].reverse());
+        const sortedProjects = await sortProjectsByGithubLastUpdated(data);
+        setProjects(sortedProjects);
       } finally {
         setLoading(false);
       }

--- a/src/services/projectActions.ts
+++ b/src/services/projectActions.ts
@@ -64,3 +64,63 @@ export async function getProjectId(id: string): Promise<Project | null> {
 
   return data ? data[0] : null;
 }
+
+type GithubRepoMeta = {
+  pushed_at: string;
+};
+
+function getRepoPathFromGithubUrl(url: string): string | null {
+  try {
+    const parsedUrl = new URL(url);
+    if (parsedUrl.hostname !== "github.com") {
+      return null;
+    }
+
+    const [owner, repo] = parsedUrl.pathname
+      .split("/")
+      .filter(Boolean)
+      .slice(0, 2);
+
+    if (!owner || !repo) {
+      return null;
+    }
+
+    return `${owner}/${repo.replace(/\.git$/, "")}`;
+  } catch {
+    return null;
+  }
+}
+
+export async function sortProjectsByGithubLastUpdated(
+  projectList: Project[],
+): Promise<Project[]> {
+  const datedProjects = await Promise.all(
+    projectList.map(async (project) => {
+      const repoPath = getRepoPathFromGithubUrl(project.github);
+      if (!repoPath) {
+        return { project, lastUpdated: "" };
+      }
+
+      try {
+        const response = await fetch(`https://api.github.com/repos/${repoPath}`);
+
+        if (!response.ok) {
+          return { project, lastUpdated: "" };
+        }
+
+        const data = (await response.json()) as GithubRepoMeta;
+        return { project, lastUpdated: data.pushed_at ?? "" };
+      } catch {
+        return { project, lastUpdated: "" };
+      }
+    }),
+  );
+
+  return datedProjects
+    .sort((a, b) => {
+      const aTime = a.lastUpdated ? new Date(a.lastUpdated).getTime() : 0;
+      const bTime = b.lastUpdated ? new Date(b.lastUpdated).getTime() : 0;
+      return bTime - aTime;
+    })
+    .map(({ project }) => project);
+}


### PR DESCRIPTION
### Motivation
- Ensure project cards are ordered by the most recent GitHub activity so projects like Team Clean or Portfolio appear first when they were updated more recently.

### Description
- Added `getRepoPathFromGithubUrl` and `GithubRepoMeta` in `src/services/projectActions.ts` to parse GitHub repo paths and read `pushed_at` metadata.
- Implemented `sortProjectsByGithubLastUpdated(projectList)` which fetches each repo's `pushed_at` via the GitHub API and returns projects sorted newest-first.
- Updated `src/pages/ProjectsPage.tsx` to import and use `sortProjectsByGithubLastUpdated` for both Supabase-loaded projects and local fallback projects.
- If a project has a non-GitHub URL or the GitHub API request fails, the code leaves that project but treats its timestamp as empty so it sorts after projects with valid timestamps.

### Testing
- Ran `npm run build` which completed successfully (`tsc -b && vite build`) ✅.
- Ran `npm run lint` which failed due to an existing `react-refresh/only-export-components` warning in `src/components/AuthProvider.tsx` unrelated to these changes ⚠️.
- Verified the app compiles and bundles in the production build step (`vite build`) as part of `npm run build` ✅.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c40ab694a08327a182226fc6f598cd)